### PR TITLE
fix empty and nonEmpty matchers

### DIFF
--- a/lib/matchers/core.js
+++ b/lib/matchers/core.js
@@ -70,7 +70,7 @@ ass.register({
     desc: 'is empty',
     fail: 'was ${ actual }',
     test: function (actual) {
-      return actual != null && actual.length > 0;
+      return actual == null || actual.length === 0;
     }
   },
   nonEmpty: {
@@ -78,7 +78,7 @@ ass.register({
     desc: 'is not empty',
     fail: 'was ${ actual }',
     test: function (actual) {
-      return actual == null || actual.length === 0;
+      return actual != null && actual.length > 0;
     }
   },
   truthy: {
@@ -204,7 +204,7 @@ ass.register({
     aliases: [ 'eql', 'eqls' ],
     help: [
       'Checks deep non-strict equality between the value and its expected.',
-      'It understand ass expressions so you can combine them at will in the',
+      'It understands ass expressions so you can combine them at will in the',
       'expected value.'
     ],
     desc: 'to equal {{expected}}',
@@ -356,7 +356,7 @@ ass.register({
     help: 'Check that value is a DOM element',
     desc: 'to be a DOM element',
     test: function (actual) {
-      return _.isElement(actual)
+      return _.isElement(actual);
     }
   },
   error: {
@@ -485,7 +485,7 @@ ass.register({
       }
 
       if (!_.isObject(actual)) {
-        return 'got {{actual}}'
+        return 'got {{actual}}';
       }
 
       // Compare objects with .where
@@ -602,7 +602,7 @@ ass.register({
       'Note: It supports negative indexes'
     ],
     desc: 'get index ${ args.join(", ") }',
-    test: function (actual, idx) {
+    test: function (actual, index) {
       if (!_.isArray(actual) && !_.isString(actual)) {
         return 'not an array or a string: ${actual}';
       }
@@ -649,7 +649,6 @@ ass.register({
       );
     }
   },
-
 
   slice: {
     help: [
@@ -832,7 +831,6 @@ ass.register({
       );
     }
   },
-
 
   store: {
     help: [


### PR DESCRIPTION
With **master** branch:

```
> ass('DrSlump').string.nonEmpty.test();
AssError:

 Passed: to be a string
 Failed: is not empty
    But: was DrSlump

    at repl:1:22
    at REPLServer.self.eval (repl.js:110:21)
    at repl.js:249:20
    at REPLServer.self.eval (repl.js:122:7)
    at Interface.<anonymous> (repl.js:239:12)
    at Interface.EventEmitter.emit (events.js:95:17)
    at Interface._onLine (readline.js:202:10)
    at Interface._line (readline.js:531:8)
    at Interface._ttyWrite (readline.js:760:14)
    at ReadStream.onkeypress (readline.js:99:10)
```

With **feature/fix-non-empty-empty-matchers** branch:

> ass('DrSlump').string.nonEmpty.test();
> true

With **master** branch:

```
> ass('').string.empty.test();
AssError:

 Passed: to be a string
 Failed: is empty
    But: was

    at repl:1:15
    at REPLServer.self.eval (repl.js:110:21)
    at repl.js:249:20
    at REPLServer.self.eval (repl.js:122:7)
    at Interface.<anonymous> (repl.js:239:12)
    at Interface.EventEmitter.emit (events.js:95:17)
    at Interface._onLine (readline.js:202:10)
    at Interface._line (readline.js:531:8)
    at Interface._ttyWrite (readline.js:760:14)
    at ReadStream.onkeypress (readline.js:99:10)
```

With **feature/fix-non-empty-empty-matchers** branch:

> ass('').string.empty.test();
> true
