### PR TITLE
prevent raising an Exception if simon is not installed

### DIFF
--- a/main.js
+++ b/main.js
@@ -35,8 +35,12 @@ patches.lodash(require('lodash'));
 
 if (global.sinon && global.sinon.match) {
   patches.sinon(global.sinon);
-} else if (require.resolve && require.resolve('sinon')) {
-  patches.sinon(require('sinon'));
+} else if (require.resolve) {
+    try {
+      patches.sinon(require('sinon'));
+    } catch (e) {
+        // sinon is not installed
+    }
 }
 
 


### PR DESCRIPTION
This line throws an Error if `sinon` is not defined.

```
module.js:340
    throw err;
          ^
Error: Cannot find module 'sinon'
  at Function.Module._resolveFilename (module.js:338:15)
  at Function.require.resolve (module.js:384:19)
  at Object.<anonymous> (/Users/juan/projects/personal/strava-es6/node_modules/ass-ert/main.js:38:39)
  at Module._compile (module.js:456:26)
```

`require.resolve('sinon')` will return the file where `sinon` is defined, or throw an exception if undefined.

Hack to silent the error. I could not find an easy way to understand if the dependency is available.
